### PR TITLE
Fix the issue that 'media' appears twice in url

### DIFF
--- a/qiniustorage/backends.py
+++ b/qiniustorage/backends.py
@@ -60,7 +60,7 @@ class QiniuStorage(Storage):
         self.bucket_manager = BucketManager(self.auth)
 
     def _clean_name(self, name):
-        return force_text(name)
+        return force_text(name).lstrip('/').lstrip(self.location)
 
     def _normalize_name(self, name):
         return ("%s/%s"% (self.location, name.lstrip('/'))).lstrip('/')

--- a/qiniustorage/backends.py
+++ b/qiniustorage/backends.py
@@ -60,10 +60,14 @@ class QiniuStorage(Storage):
         self.bucket_manager = BucketManager(self.auth)
 
     def _clean_name(self, name):
-        return force_text(name).lstrip('/').lstrip(self.location)
+        return force_text(name)
 
     def _normalize_name(self, name):
-        return ("%s/%s"% (self.location, name.lstrip('/'))).lstrip('/')
+        name = name.lstrip('/')
+        if name.startswith(self.location + '/'):
+            return name
+        else:
+            return ("%s/%s"% (self.location, name)).lstrip('/')
 
     def _open(self, name, mode='rb'):
         return QiniuFile(name, self, mode)


### PR DESCRIPTION
Since name of FileField contains the 'media' prefix, I modified the _normalize_name function, so that while the name starts with 'location'+'/', we don't add 'location' to the result. The url appears correct this way.