### PR TITLE
content should be opened and closed by HttpRequest

### DIFF
--- a/qiniustorage/backends.py
+++ b/qiniustorage/backends.py
@@ -109,18 +109,12 @@ class QiniuStorage(Storage):
         cleaned_name = self._clean_name(name)
         name = self._normalize_name(cleaned_name)
 
-        if hasattr(content, 'open'):
-            # Since Django 1.6, content should be a instance
-            # of `django.core.files.File`
-            content.open()
-
         if hasattr(content, 'chunks'):
             content_str = b''.join(chunk for chunk in content.chunks())
         else:
             content_str = content.read()
 
         self._put_file(name, content_str)
-        content.close()
         return cleaned_name
 
     def _put_file(self, name, content):


### PR DESCRIPTION
文件上传在被保存在storage之前，先由django的upload handlers来存储在内存或者硬盘上，作为content参数传入，close会在[HttpRequest.close](https://github.com/django/django/blob/stable/1.8.x/django/http/request.py#L277)被调用时content.close

其他的存储实现也是这样的：
https://github.com/jschneier/django-storages/blob/master/storages/backends/azure_storage.py
