### PR TITLE
修复无法上传中文名文件的问题

### DIFF
--- a/qiniustorage/backends.py
+++ b/qiniustorage/backends.py
@@ -141,7 +141,7 @@ class QiniuStorage(Storage):
 
     def _file_stat(self, name, silent=False):
         name = self._normalize_name(self._clean_name(name))
-
+        name = name.encode('utf-8')
         ret, info = self.bucket_manager.stat(self.bucket_name, name)
         if ret is None and not silent:
             raise QiniuError(info)


### PR DESCRIPTION
上传中文名文件报错
UnicodeEncodeError  urlsafe_base64_encode('{0}:{1}'.format(bucket, key))
貌似之前有修复过，现在漏掉了？