### PR TITLE
兼容 django原生 storage

### DIFF
--- a/qiniustorage/backends.py
+++ b/qiniustorage/backends.py
@@ -220,6 +220,7 @@ class QiniuPrivateStorage(QiniuStorage):
 
 class QiniuFile(File):
     def __init__(self, name, storage, mode):
+        super(QiniuFile, self).__init__()
         self._storage = storage
         self._name = name[len(self._storage.location):].lstrip('/')
         self._mode = mode

--- a/qiniustorage/backends.py
+++ b/qiniustorage/backends.py
@@ -220,13 +220,13 @@ class QiniuPrivateStorage(QiniuStorage):
 
 class QiniuFile(File):
     def __init__(self, name, storage, mode):
-        super(QiniuFile, self).__init__()
         self._storage = storage
         self._name = name[len(self._storage.location):].lstrip('/')
         self._mode = mode
         self.file = six.BytesIO()
         self._is_dirty = False
         self._is_read = False
+        super(QiniuFile, self).__init__(self.file，self._name)
 
     @property
     def size(self):


### PR DESCRIPTION
由于django自身storage是带了 name 这个属性的, 由于这边没有去继承父类构造函数导致了其没有name这个属性，从而导致了和django自带storage的api不一致 , 加了这个supper().__init__ 就能尽量和原生一致了